### PR TITLE
Move Http client to DI

### DIFF
--- a/Movie.PoC.Api/Controllers/FilmController.cs
+++ b/Movie.PoC.Api/Controllers/FilmController.cs
@@ -21,7 +21,7 @@ namespace Movie.PoC.Api.Controllers
         {
             var query = new FilmService.GetFilmDataQuery(request);
             var result = await _mediator.Send(query);
-            return result is not null ? Ok(request) : BadRequest();
+            return result is not null ? Ok(result) : BadRequest();
         }
     }
 }

--- a/Movie.PoC.Api/Features/Films/FilmService.cs
+++ b/Movie.PoC.Api/Features/Films/FilmService.cs
@@ -8,21 +8,13 @@ namespace Movie.PoC.Api.Features.Films
     {
         public record GetFilmDataQuery(string ImdbId) : IRequest<FilmDataRaw?>;
 
-        internal sealed class GetFilmDataHandler : IRequestHandler<GetFilmDataQuery, FilmDataRaw?>
+        internal sealed class GetFilmDataHandler(HttpClient client) : IRequestHandler<GetFilmDataQuery, FilmDataRaw?>
         {
-            private readonly HttpClient _httpClient;
-
-            public GetFilmDataHandler() => _httpClient = new HttpClient
-            {
-                BaseAddress = new Uri("https://www.omdbapi.com/")
-            };
-
-
             public async Task<FilmDataRaw?> Handle(GetFilmDataQuery request, CancellationToken cancellationToken)
             {
                 string url = $"?i={request.ImdbId}&apikey=66b0c81f".ToString();
 
-                var response = await _httpClient.GetAsync(url, cancellationToken);
+                var response = await client.GetAsync(url, cancellationToken);
                 if (!response.IsSuccessStatusCode)
                 {
                     return null;

--- a/Movie.PoC.Api/Program.cs
+++ b/Movie.PoC.Api/Program.cs
@@ -1,7 +1,10 @@
 using FluentValidation;
+using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Movie.PoC.Api.Contracts.Requests;
 using Movie.PoC.Api.Database;
+using Movie.PoC.Api.Entities;
+using Movie.PoC.Api.Features.Films;
 using Movie.PoC.Api.Features.Users;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -15,6 +18,8 @@ builder.Services.AddSwaggerGen();
 
 var dbPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "movie.db");
 builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite($"Data Source={dbPath}"));
+builder.Services.AddHttpClient<IRequestHandler<FilmService.GetFilmDataQuery, FilmDataRaw?>, FilmService.GetFilmDataHandler>(
+    w => w.BaseAddress = new Uri("https://www.omdbapi.com/"));
 
 builder.Services.AddScoped<IValidator<CreateUserRequest>, CreateUserValidator>();
 builder.Services.AddMediatR(c => c.RegisterServicesFromAssemblyContaining<Program>());


### PR DESCRIPTION
This will not new up a httpclient but instead use the DI container to handle it which is better due to issue https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines