### PR TITLE
Move ApiKey To AppSettings

### DIFF
--- a/Movie.PoC.Api/Features/Films/FilmService.cs
+++ b/Movie.PoC.Api/Features/Films/FilmService.cs
@@ -1,6 +1,8 @@
 ﻿using MediatR;
 using Movie.PoC.Api.Entities;
 using System.Text.Json;
+using Microsoft.Extensions.Options;
+using Movie.PoC.Api.Settings;
 
 namespace Movie.PoC.Api.Features.Films
 {
@@ -8,11 +10,11 @@ namespace Movie.PoC.Api.Features.Films
     {
         public record GetFilmDataQuery(string ImdbId) : IRequest<FilmDataRaw?>;
 
-        internal sealed class GetFilmDataHandler(HttpClient client) : IRequestHandler<GetFilmDataQuery, FilmDataRaw?>
+        internal sealed class GetFilmDataHandler(HttpClient client,IOptions<OmDbSettings> settings) : IRequestHandler<GetFilmDataQuery, FilmDataRaw?>
         {
             public async Task<FilmDataRaw?> Handle(GetFilmDataQuery request, CancellationToken cancellationToken)
             {
-                string url = $"?i={request.ImdbId}&apikey=66b0c81f".ToString();
+                string url = $"?i={request.ImdbId}&apikey={settings.Value.ApiKey}".ToString();
 
                 var response = await client.GetAsync(url, cancellationToken);
                 if (!response.IsSuccessStatusCode)

--- a/Movie.PoC.Api/Program.cs
+++ b/Movie.PoC.Api/Program.cs
@@ -6,6 +6,7 @@ using Movie.PoC.Api.Database;
 using Movie.PoC.Api.Entities;
 using Movie.PoC.Api.Features.Films;
 using Movie.PoC.Api.Features.Users;
+using Movie.PoC.Api.Settings;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -17,6 +18,7 @@ builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();
 
 var dbPath = Path.Join(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "movie.db");
+builder.Services.Configure<OmDbSettings>(builder.Configuration.GetSection(nameof(OmDbSettings)));
 builder.Services.AddDbContext<ApplicationDbContext>(options => options.UseSqlite($"Data Source={dbPath}"));
 builder.Services.AddHttpClient<IRequestHandler<FilmService.GetFilmDataQuery, FilmDataRaw?>, FilmService.GetFilmDataHandler>(
     w => w.BaseAddress = new Uri("https://www.omdbapi.com/"));

--- a/Movie.PoC.Api/Settings/OmDbSettings.cs
+++ b/Movie.PoC.Api/Settings/OmDbSettings.cs
@@ -1,0 +1,6 @@
+namespace Movie.PoC.Api.Settings;
+
+public class OmDbSettings
+{
+    public string ApiKey { get; set; }
+}

--- a/Movie.PoC.Api/appsettings.json
+++ b/Movie.PoC.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
+  "OmDbSettings": {
+    "ApiKey" : "66b0c81f"
+  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
This will move the api key in to appsettings rather than hard coded in service. As this is tightly coupled might be a idea to make the handler omdb specific but meh